### PR TITLE
fixed regression

### DIFF
--- a/scripts/SolrIndexBuilder.php
+++ b/scripts/SolrIndexBuilder.php
@@ -165,7 +165,7 @@ class SolrIndexBuilder {
 
         $indexer = Opus_Search_Service::selectIndexingService( 'indexBuilder' );
 
-        if ( !$this->_deleteAllDocs ) {
+        if ($this->_deleteAllDocs) {
             $indexer->removeAllDocumentsFromIndex();
         }
 


### PR DESCRIPTION
Der Fehler wurde offenbar beim Umbau der Klasse eingeschleppt. Das alte Verfahren (vor dem Umbau) war das vollständige Löschen des Index vor der Reindexierung, wenn dem Script keine Argumente (start bzw. end) beim Aufruf mitgegeben werden. Der Pull Request stellt das alte Verhalten wieder her.