### PR TITLE
Update periodicalpart.xml

### DIFF
--- a/application/configs/doctypes/periodicalpart.xml
+++ b/application/configs/doctypes/periodicalpart.xml
@@ -33,7 +33,7 @@
  * @license     http://www.gnu.org/licenses/gpl.html General Public License
  */
  -->
-<documenttype name="periodical"
+<documenttype name="periodicalpart"
               xmlns="http://www.opus-repository.org/schema/documenttype"
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:schemaLocation="http://www.opus-repository.org/schema/documenttype http://www.opus-repository.org/schema/documenttype.xsd">


### PR DESCRIPTION
Zufallsfund: falscher Name des Dokumenttyps *periodicalpart* im XML; allerdings wird der Wert im Attribut `name` vom Element `documenttype` im Code scheinbar gar nicht weiter ausgewertet, weil beim Anlegen eines neuen Dokuments mit diesem Typ in der DB der korrekte Bezeichner *periodicalpart* steht. Daher kann man sich den Wert im `name`-Attribut evtl. auch ganz sparen und damit die Anzahl der Redundanzen verringern.